### PR TITLE
initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/

--- a/README.md
+++ b/README.md
@@ -1,57 +1,19 @@
-# Mesh Interview Task
+# Github Repositories API
+Simple GitHub Repositories API retrieves user metadata along with user repositories
 
-The Mesh interview task is to write a simple HTTP server that is integrated with the GitHub API. It can be written in whatever language you are most comfortable with. You can find all GitHub documentation at the following URL.
+## Dependencies:
+* github.com/gorilla/mux
+    * HTTP router
 
-https://developer.github.com/
+## Project Structures: 
+### clients
+It's a package to manage client connectivity to GitHub.
+It contains the interface, concrete client implementation, and mocks.
 
-### Implementation
+### handlers
+Handlers handles the GET request to get GitHub metadata.
+The unit test verifies http status code and response body
 
-The server should expose a single API that returns a user payload containing information about your personal GitHub account. The payload should look like the following:
+### model
+It's a package for response payload.
 
-```
-GET /githubPayload
-
-{
-  user: {
-    githubHandle:
-    githubURL:
-    avatarURL:
-    email:
-    followerCount:
-    repositories: [
-      {
-        name:
-        url:
-        commitCount:
-        pullRequestCount:
-      },
-      {...}
-    ]
-  }
-}
-```
-
-### Considerations
-
- * The server should not contain any hard coded information. Rather, all payload information should come directly from GitHub's API. It is up to determine you how the integration will be built and the GitHub data will be processed.
- * Please be sure to strip out any personal information from your payload.
-
-### Quality
-
-We would like you to treat this task as if you were doing it for a client - i.e. use the best practices that you would like to see in a piece of work for others. Keep in mind code formatting, project organization, documentation etc.
-
-### Project Submission
-
-Please fork this repository into your personal account. When your work is ready for review, please send us a link.
-
-### Time Expectation
-
-This task should not take you more than ~4 hours.
-
-### Submission
-
-Once you would like to submit, please send a pull request with your changes. Email the Mesh team member you have been interfacing with to let them know your project is ready for review.
-
-### Help
-
-Please feel free to ping us with any questions you might have as you get going. Otherwise we are excited to see what you build!

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,57 @@
+# Mesh Interview Task
+
+The Mesh interview task is to write a simple HTTP server that is integrated with the GitHub API. It can be written in whatever language you are most comfortable with. You can find all GitHub documentation at the following URL.
+
+https://developer.github.com/
+
+### Implementation
+
+The server should expose a single API that returns a user payload containing information about your personal GitHub account. The payload should look like the following:
+
+```
+GET /githubPayload
+
+{
+  user: {
+    githubHandle:
+    githubURL:
+    avatarURL:
+    email:
+    followerCount:
+    repositories: [
+      {
+        name:
+        url:
+        commitCount:
+        pullRequestCount:
+      },
+      {...}
+    ]
+  }
+}
+```
+
+### Considerations
+
+ * The server should not contain any hard coded information. Rather, all payload information should come directly from GitHub's API. It is up to determine you how the integration will be built and the GitHub data will be processed.
+ * Please be sure to strip out any personal information from your payload.
+
+### Quality
+
+We would like you to treat this task as if you were doing it for a client - i.e. use the best practices that you would like to see in a piece of work for others. Keep in mind code formatting, project organization, documentation etc.
+
+### Project Submission
+
+Please fork this repository into your personal account. When your work is ready for review, please send us a link.
+
+### Time Expectation
+
+This task should not take you more than ~4 hours.
+
+### Submission
+
+Once you would like to submit, please send a pull request with your changes. Email the Mesh team member you have been interfacing with to let them know your project is ready for review.
+
+### Help
+
+Please feel free to ping us with any questions you might have as you get going. Otherwise we are excited to see what you build!

--- a/clients/github_api.go
+++ b/clients/github_api.go
@@ -1,0 +1,9 @@
+package clients
+
+import "github.com/elumbantoruan/mesh-interview-task/model"
+
+// GitHubAPI interface
+type GitHubAPI interface {
+	GetUserMetadata(account string) (*model.UserMetadata, error)
+	GetUserRepositories(um *model.UserMetadata) ([]model.Repository, error)
+}

--- a/clients/github_client.go
+++ b/clients/github_client.go
@@ -1,0 +1,142 @@
+package clients
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/elumbantoruan/mesh-interview-task/model"
+)
+
+// GitHubClient implements GitHubAPI interface
+type GitHubClient struct {
+}
+
+// NewGitHubClient creates GithubClient
+func NewGitHubClient() *GitHubClient {
+	return &GitHubClient{}
+}
+
+// GetUserMetadata returns user metadata
+func (c *GitHubClient) GetUserMetadata(account string) (*model.UserMetadata, error) {
+	var user model.UserMetadata
+	req, _ := http.NewRequest("GET", fmt.Sprintf("https://api.github.com/users/%s", account), nil)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	var usermetadata = make(map[string]interface{})
+	json.NewDecoder(resp.Body).Decode(&usermetadata)
+
+	if _, ok := usermetadata["login"]; !ok {
+		// most likely you get throttle
+		if _, ok := usermetadata["message"]; ok {
+			return nil, fmt.Errorf("ERROR: %v", usermetadata["message"].(string))
+		}
+		return nil, errors.New("UNKNOWN ERROR has occured")
+	}
+
+	user.GithubHandle = usermetadata["login"].(string)
+	user.GithubURL = usermetadata["url"].(string)
+	user.AvatarURL = usermetadata["avatar_url"].(string)
+
+	user.FollowerCount = usermetadata["followers"].(float64)
+
+	emailURL := fmt.Sprintf("https://api.github.com/users/%s/events/public", user.GithubHandle)
+	req, _ = http.NewRequest("GET", emailURL, nil)
+	client = &http.Client{}
+	resp, err = client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	var eventsData []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&eventsData)
+
+	var (
+		payload map[string]interface{}
+		commits []interface{}
+		commit  map[string]interface{}
+		author  map[string]interface{}
+	)
+
+	for _, v := range eventsData {
+		payload = v["payload"].(map[string]interface{})
+		if cm, ok := payload["commits"]; ok {
+			commits = cm.([]interface{})
+			for _, c := range commits {
+				commit = c.(map[string]interface{})
+				author = commit["author"].(map[string]interface{})
+				user.Email = author["email"].(string)
+				break
+			}
+			break
+		}
+	}
+
+	user.RepositoryURL = usermetadata["repos_url"].(string)
+
+	return &user, nil
+}
+
+// GetUserRepositories returns list of user repositories
+func (c *GitHubClient) GetUserRepositories(um *model.UserMetadata) ([]model.Repository, error) {
+	var repositories []model.Repository
+	req, _ := http.NewRequest("GET", um.RepositoryURL, nil)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	var repos []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&repos)
+
+	for _, r := range repos {
+		var repository model.Repository
+		repository.Name = r["name"].(string)
+		repository.URL = r["url"].(string)
+
+		commitCount, err := c.CountCommits(fmt.Sprintf("https://api.github.com/repos/%s/%s/commits", um.GithubHandle, repository.Name))
+		if err != nil {
+			return nil, err
+		}
+		repository.CommitCount = commitCount
+
+		prCount, err := c.CountPullRequests(fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls?state=all", um.GithubHandle, repository.Name))
+		if err != nil {
+			return nil, err
+		}
+		repository.PullRequestCount = prCount
+		repositories = append(repositories, repository)
+	}
+	return repositories, nil
+}
+
+// CountCommits .
+func (c *GitHubClient) CountCommits(endpoint string) (int, error) {
+	req, _ := http.NewRequest("GET", endpoint, nil)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return -1, err
+	}
+	var commits []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&commits)
+
+	return len(commits), nil
+}
+
+// CountPullRequests .
+func (c *GitHubClient) CountPullRequests(endpoint string) (int, error) {
+	req, _ := http.NewRequest("GET", endpoint, nil)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return -1, err
+	}
+	var prs []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&prs)
+
+	return len(prs), nil
+}

--- a/clients/github_mock.go
+++ b/clients/github_mock.go
@@ -1,0 +1,32 @@
+package clients
+
+import (
+	"fmt"
+
+	"github.com/elumbantoruan/mesh-interview-task/model"
+)
+
+// GitHubMock mocks the GitHubAPI
+type GitHubMock struct{}
+
+// GetUserMetadata returns user metadata
+func (g GitHubMock) GetUserMetadata(account string) (*model.UserMetadata, error) {
+	return &model.UserMetadata{
+		User: model.User{
+			GithubHandle:  account,
+			FollowerCount: 100,
+		},
+		RepositoryURL: fmt.Sprintf("https://api.github.com/users/%s/repos", account),
+	}, nil
+}
+
+// GetUserRepositories .
+func (g GitHubMock) GetUserRepositories(um *model.UserMetadata) ([]model.Repository, error) {
+	return []model.Repository{
+		{
+			Name:             "myrepo",
+			CommitCount:      10,
+			PullRequestCount: 10,
+		},
+	}, nil
+}

--- a/handlers/github_repositories.go
+++ b/handlers/github_repositories.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/elumbantoruan/mesh-interview-task/clients"
+	"github.com/elumbantoruan/mesh-interview-task/model"
+)
+
+// GitHubRepositories represents github user metadata and user repositories
+type GitHubRepositories struct {
+	api clients.GitHubAPI
+}
+
+// NewGitHubRepositories creates a new instance of GithubRepositories
+func NewGitHubRepositories(api clients.GitHubAPI) *GitHubRepositories {
+	return &GitHubRepositories{
+		api: api,
+	}
+}
+
+// HandleGetRepositories fetches github metadata which includes user information
+// and user repositories
+func (g *GitHubRepositories) HandleGetRepositories(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+
+	if _, ok := vars["account"]; !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	um, err := g.api.GetUserMetadata(vars["account"])
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(model.NewErrorMessage(err))
+	}
+
+	repos, err := g.api.GetUserRepositories(um)
+	if err != nil {
+		log.Println(err)
+	}
+	var user model.User
+	user = um.User
+	user.Repositories = repos
+
+	gh := model.GithubMetadata{User: user}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(gh)
+}

--- a/handlers/github_repositories_test.go
+++ b/handlers/github_repositories_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elumbantoruan/mesh-interview-task/clients"
+	"github.com/elumbantoruan/mesh-interview-task/model"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// Returns not found as query parameter "account" is not found
+func TestGitHubRepositories_HandleGetRepositories_NotFound(t *testing.T) {
+	request, _ := http.NewRequest("GET", "githubrepositories", strings.NewReader(""))
+	mapper := map[string]string{}
+	request = mux.SetURLVars(request, mapper)
+
+	responseRecorder := httptest.NewRecorder()
+
+	api := clients.GitHubMock{}
+	handler := NewGitHubRepositories(api)
+	handler.HandleGetRepositories(responseRecorder, request)
+
+	assert.Equal(t, http.StatusNotFound, responseRecorder.Code)
+
+}
+
+func TestGitHubRepositories_HandleGetRepositories(t *testing.T) {
+	account := "testaccount"
+	request, _ := http.NewRequest("GET", "githubrepositories", strings.NewReader(""))
+	mapper := map[string]string{
+		"account": account,
+	}
+	request = mux.SetURLVars(request, mapper)
+
+	responseRecorder := httptest.NewRecorder()
+
+	api := clients.GitHubMock{}
+	handler := NewGitHubRepositories(api)
+	handler.HandleGetRepositories(responseRecorder, request)
+
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	// verify if body returns appropriate payload
+	var gh model.GithubMetadata
+	json.NewDecoder(responseRecorder.Body).Decode(&gh)
+
+	assert.Equal(t, gh.User.GithubHandle, account)
+
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/elumbantoruan/mesh-interview-task/clients"
+	"github.com/elumbantoruan/mesh-interview-task/handlers"
+)
+
+func main() {
+
+	m, err := registerHandlers()
+	if err != nil {
+		log.Panic(err)
+	}
+	http.Handle("/", m)
+
+	err = http.ListenAndServe(":5000", nil)
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+func registerHandlers() (*mux.Router, error) {
+	m := mux.NewRouter()
+
+	// Register GitHubRepositories handler
+	// creates an api
+	// then set it into GithubRepositories handler
+	api := clients.NewGitHubClient()
+	gh := handlers.NewGitHubRepositories(api)
+	m.HandleFunc("/githubrepositories/{account}", gh.HandleGetRepositories).Methods("GET")
+
+	return m, nil
+}

--- a/model/model.go
+++ b/model/model.go
@@ -1,0 +1,40 @@
+package model
+
+// GithubMetadata contains metadata for user github account
+type GithubMetadata struct {
+	User User `json:"user"`
+}
+
+// User represents GitHub user information along with user repositories
+type User struct {
+	GithubHandle  string
+	GithubURL     string
+	AvatarURL     string
+	Email         string
+	FollowerCount float64
+	Repositories  []Repository
+}
+
+// UserMetadata represents User information and the endpoint to get the list of user repositories
+type UserMetadata struct {
+	User          `json:"user"`
+	RepositoryURL string `json:"repositoryURL"`
+}
+
+// Repository represents GitHub repositoy metadata
+type Repository struct {
+	Name             string `json:"name"`
+	URL              string `json:"url"`
+	CommitCount      int    `json:"commitCount"`
+	PullRequestCount int    `json:"pullRequestCount"`
+}
+
+// ErrorMessage contains the error message
+type ErrorMessage struct {
+	Message string `json:"message"`
+}
+
+// NewErrorMessage returns ErrorMessage type from the error type
+func NewErrorMessage(err error) ErrorMessage {
+	return ErrorMessage{Message: err.Error()}
+}


### PR DESCRIPTION
# Github Repositories API
Simple GitHub Repositories API retrieves user metadata along with user repositories

## Dependencies:
* github.com/gorilla/mux
    * HTTP router

## Project Structures: 
### clients
It's a package to manage client connectivity to GitHub.
It contains the interface, concrete client implementation, and mocks.

### handlers
Handlers handles the GET request to get GitHub metadata.
The unit test verifies http status code and response body

### model
It's a package for response payload.

